### PR TITLE
Mark "Unofficial"

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   // See: https://respec.org/docs/ for all configuration options
   var respecConfig = {
     shortName: "wm-session-flow",
-    specStatus: "base",
+    specStatus: "unofficial",
     noRecTrack: true,
     edDraftURI: "n/a",
     editors: [{


### PR DESCRIPTION
I think this is less than a note, even, right? Is it in a Working Group? I believe the correct respec status here should be 'unofficial' and it will make the spec visually indicate that (https://github.com/speced/respec/wiki/specStatus)